### PR TITLE
Set up dev environment + document Cursor Cloud specifics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,27 @@
 - When auditing an MCP-backed product, distinguish tools exported directly by the MCP
   server from tools available internally to remote agents. Absence from `tools/list`
   does not prove that the product lacks that capability.
+
+## Cursor Cloud specific instructions
+
+Two services: `backend/` (FastAPI, managed by `uv`) and `frontend/` (React + Vite).
+The update script keeps deps fresh via `uv sync` (backend) and `npm ci` (frontend); `uv`
+installs to `~/.local/bin` (already on `PATH` via `~/.bashrc`).
+
+- Backend runs credential-free: startup, storage, project reads, export/pack pipeline,
+  and the MCP contract do not need cloud keys. Only the creative image providers
+  (Gemini/Vertex, Azure OpenAI, ComfyUI) require config in `backend/.env`; without them
+  `/ready` reports providers unavailable and `generate`/`animate` return provider errors
+  by design — this is expected, not a setup failure.
+- Run both from their own dirs (see `README.md`): backend `uv run uvicorn app.main:app
+  --reload` on :8000, frontend `npm run dev` on :5173. Vite proxies API paths to :8000,
+  so open the app at http://localhost:5173.
+- Standard checks live in `README.md`/`CONTRIBUTING.md`: backend `uv run pytest`,
+  `uv run python ../scripts/doctor.py`, `uv run python ../scripts/smoke_mcp.py`;
+  frontend `npm test` and `npm run build`. Backend tests must stay deterministic and must
+  not make paid provider calls (mock providers, as existing tests do).
+- To exercise the credential-free creative core end-to-end without paid APIs, follow the
+  test pattern: `create_app(remover=<fake>)` with `get_gemini_client` overridden by a fake
+  provider (see `backend/tests/test_export_multi.py`), then generate/animate/export. This
+  writes real frames a running server can then pack/export (sheet, atlas, frames ZIP,
+  Godot bundle).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the local development environment for SpriteGameGen (FastAPI backend + React/Vite frontend), and documented durable Cursor Cloud setup notes in `AGENTS.md`. No application code was changed.

## Environment

- Backend: Python 3.12 via `uv` — `uv sync --locked --extra dev` (backend startup, storage, export pipeline, and MCP contract are credential-free).
- Frontend: Node 22 — `npm ci`.
- Update script (VM startup): guarded `uv` install, `uv sync --locked --extra dev`, `npm ci`.

## Verification

| Service | Lint/Type | Test | Build | Run |
|---|---|---|---|---|
| backend | `uv run python ../scripts/doctor.py` (Overall: ready), `uv run python ../scripts/smoke_mcp.py` (contract OK), `uv pip check` | `uv run pytest` — 322 passed | n/a | `uv run uvicorn app.main:app --reload` (:8000, `/health` ok) |
| frontend | `tsc` (via build) | `npm test` — 55 passed | `npm run build` OK | `npm run dev` (:5173, proxies API to :8000) |

## Hello-world (credential-free core)

Image generation needs paid provider keys (Gemini/Azure), so — mirroring the repo's own tests — I seeded a real project via the app pipeline with the provider stubbed, then drove the deterministic core through the running app in the browser: opened the project, and exported a game-ready **sprite sheet** (PNG + JSON atlas + frames ZIP) and a **character bundle** (ZIP). All succeeded.

[sprite_export_hello_world.mp4](https://cursor.com/agents/bc-93ea1419-f6cc-4a76-854a-b3ca43176dc2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsprite_export_hello_world.mp4)

[Sprite sheet export success](https://cursor.com/agents/bc-93ea1419-f6cc-4a76-854a-b3ca43176dc2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexport_sprite_sheet_success.webp)
[Character bundle export success](https://cursor.com/agents/bc-93ea1419-f6cc-4a76-854a-b3ca43176dc2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexport_character_bundle_success.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93ea1419-f6cc-4a76-854a-b3ca43176dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93ea1419-f6cc-4a76-854a-b3ca43176dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cursor Cloud dev setup to `AGENTS.md`: how to run `backend/` (FastAPI via `uv`/`uvicorn`, :8000) and `frontend/` (React/Vite, :5173 with proxy), plus the standard test/build checks. Clarifies that creative providers (Gemini/Azure/ComfyUI) are optional and shows how to export using fake providers; no code changes.

<sup>Written for commit 1fdefe66e333539b3d17212f04c7323ee157b82f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Nether403/SpriteGameGen/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

