### PR TITLE
Enhance README with image and project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AI Sprite & Game Asset Tool
 
+<img width="1398" height="503" alt="image" src="https://github.com/user-attachments/assets/0d7e2faa-9d93-44f1-bb3f-2f8db24863a7" />
+
+
 A local-first character animation workbench that turns a text prompt (and optional
 reference image) into reusable animation clips and versioned engine-ready bundles.
 Azure GPT Image, Gemini, or an independently operated loopback ComfyUI server can do
@@ -8,8 +11,6 @@ sprite-sheet packing, frame ZIPs, bundle checksums, and Godot resources.
 Side-scroller walks also provide Gemini with deterministic eight-phase pose guides,
 so frames change limb geometry instead of merely restyling the same stance.
 
-See the design spec in [`docs/superpowers/specs/`](docs/superpowers/specs/) and the
-implementation plan in [`docs/superpowers/plans/`](docs/superpowers/plans/).
 
 Licensed under [Apache-2.0](LICENSE). See [CONTRIBUTING.md](CONTRIBUTING.md),
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and [SECURITY.md](SECURITY.md) before


### PR DESCRIPTION
Added an image and updated project description in README.

## Summary

<!-- What changed, why is it needed, and what user-visible impact does it have? -->

## Related Issue

<!-- Use "Closes #123" when applicable. -->

## Verification

- [ ] Backend tests: `cd backend && uv run pytest`
- [ ] Frontend tests: `cd frontend && npm test`
- [ ] Frontend build: `cd frontend && npm run build`
- [ ] Other verification is described below

<!-- Mark non-applicable checks and explain why. Include manual test steps. -->

## Safety and Scope

- [ ] I reviewed the diff for API keys, tokens, service-account files, private
      endpoints, personal data, and other credentials.
- [ ] Automated tests do not make paid or live provider calls.
- [ ] Generated project assets and local environment files are not included.
- [ ] The change is focused and does not include unrelated refactoring.
- [ ] Documentation and `CHANGELOG.md` are updated when behavior changed.

## Screenshots or Output Samples

<!-- Add redacted evidence for UI or output-quality changes when useful. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nether403/spritegamegen/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a header image and clarify the README overview to give quick visual context and explain capabilities more clearly. Remove outdated links to the design spec and implementation plan to reduce noise.

<sup>Written for commit 9c37738a39c5e005ec205889873720692d82e7c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Nether403/SpriteGameGen/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

